### PR TITLE
Use correct url for snapshots so relative resource paths are correct

### DIFF
--- a/src/PuppeteerPercy.js
+++ b/src/PuppeteerPercy.js
@@ -43,7 +43,7 @@ class PuppeteerPercy {
         const source = await page.content();
 
         const rootResource = this.client.makeResource({
-            resourceUrl: '/',
+            resourceUrl: page.url(),
             content: source,
             isRoot: true,
             mimetype: 'text/html'


### PR DESCRIPTION
if the html for a page has a relative resource url (i.e. image with a source of 'img/x.jpg'), then using '/' for the snapshot url instead of the correct path causes the images to not be found.  This uses the page.url() instead of '/'.